### PR TITLE
Update ArrayHelper.php

### DIFF
--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -248,11 +248,16 @@ final class ArrayHelper
 
         if (is_object($array)) {
             try {
-                return $array::$$key;
+                try {
+                    return $array::$$key;
+                } catch (Throwable $e) {
+                    // This is expected to fail if the property does not exist, or __get() is not implemented.
+                    // It is not reliably possible to check whether a property is accessible beforehand.
+                    return $array->$key;
+                }
             } catch (Throwable $e) {
-                // This is expected to fail if the property does not exist, or __get() is not implemented.
-                // It is not reliably possible to check whether a property is accessible beforehand.
-                return $array->$key;
+                $getter = 'get' . ucfirst($key);
+                return $array->$getter();
             }
         }
 


### PR DESCRIPTION
Try using getter for objects in getRootValue() if property not public and __get() not implemented

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #90

Allows use shortcut column definition in GridView when using Cycle ORM; the alternative is implementing __get in the Entity (bad magic) or specifying all columns in array format and using getters in the value() key - which makes using GridView with Cycle rather clunky. 
